### PR TITLE
Fix `Liquid Exception: comparison of Array with Array failed in page`

### DIFF
--- a/plugins/tag_cloud.rb
+++ b/plugins/tag_cloud.rb
@@ -66,7 +66,13 @@ module Jekyll
       # map: [[tag name, tag count]] -> [[tag name, tag weight]]
       weighted = count.map do |name, count|
         # logarithmic distribution
-        weight = (Math.log(count) - Math.log(min))/(Math.log(max) - Math.log(min))
+        if (min != max)
+            # logarithmic distribution
+            weight = (Math.log(count) - Math.log(min))/(Math.log(max) - Math.log(min))
+        else
+            # value which makes the font-size calculated below equals to 100%
+            weight = (100 - size_min) / (size_max - size_min)
+        end
         [name, weight]
       end
 
@@ -111,6 +117,7 @@ module Jekyll
       # iterate over the weighted tag Array and create the tag items
       weighted.each_with_index do |tag, i|
         name, weight = tag
+        # calculate font-size
         size = size_min + ((size_max - size_min) * weight).to_f
         size = sprintf("%.#{@precision}f", size)
         slug = name.to_url


### PR DESCRIPTION
PROBLEM

When every page which declares tag has the same tags then running:

```
$ rake generate
```

the plugins breaks with the following exception:

```
## Generating Site with Jekyll
    write source/stylesheets/screen.css
Configuration file: ... /_config.yml
            Source: source
       Destination: public
      Generating...
  Liquid Exception: comparison of Array with Array failed in _layouts/page.html
jekyll 2.5.3 | Error:  comparison of Array with Array failed
```

CAUSE

When each tag occures the same number of times, calculated over all the posts,
then in the logarithmic distribution expression:

```
# logarithmic distribution
weight = (Math.log(count) - Math.log(min))/(Math.log(max) - Math.log(min))
```

`min` is equal to `max` so `weight` assume the value `NaN` which make comparison
with numbers fails.

SOLUTION

Use logarithmic distribution only if `min` is not equals to `max` otherwise use
the value:

```
# value which makes the font-size calculated below equal to 100%
weight = (100 - size_min) / (size_max - size_min)
```

The value proposed for `weight` is the one which makes the font-size calculated
few lines below equals to 100%:

```
size = size_min + ((size_max - size_min) * weight).to_f
```

in other words as none of each tag occures more then another one then all tags
font-size must be the same: 100% is exactly the font-size of the text in the
same block either `<article>` or `<aside>`.

robbyedwards/octopress-tag-cloud#1
